### PR TITLE
#64 fix role based access

### DIFF
--- a/routes/admin.test.js
+++ b/routes/admin.test.js
@@ -97,7 +97,7 @@ describe('Admin Route Tests', () => {
       const doc = new JSDOM(response.text).window.document;
 
       // check the main navbar
-      expect(doc.querySelector('.navbar-nav>.active').getAttribute('href')).toBe('#');
+      expect(doc.querySelector('.navbar-nav>.active').getAttribute('href')).toBe('/admin');
       expect(doc.querySelector('.navbar-nav>.navbar-text').innerHTML).toContain(
         'master@uwstout.edu'
       );

--- a/routes/advise.test.js
+++ b/routes/advise.test.js
@@ -47,7 +47,7 @@ describe('Advise Route Tests', () => {
       const doc = new JSDOM(response.text).window.document;
 
       // check the main navbar
-      expect(doc.querySelector('.navbar-nav>.active').getAttribute('href')).toBe('#');
+      expect(doc.querySelector('.navbar-nav>.active').getAttribute('href')).toBe('/advise');
       expect(doc.querySelector('.navbar-nav>.navbar-text').innerHTML).toContain(
         'master@uwstout.edu'
       );

--- a/routes/manage.test.js
+++ b/routes/manage.test.js
@@ -47,7 +47,7 @@ describe('Manage Route Tests', () => {
       const doc = new JSDOM(response.text).window.document;
 
       // check the main navbar
-      expect(doc.querySelector('.navbar-nav>.active').getAttribute('href')).toBe('#');
+      expect(doc.querySelector('.navbar-nav>.active').getAttribute('href')).toBe('/manage');
       expect(doc.querySelector('.navbar-nav>.navbar-text').innerHTML).toContain(
         'master@uwstout.edu'
       );

--- a/routes/manage.test.js
+++ b/routes/manage.test.js
@@ -109,10 +109,6 @@ describe('Manage Route Tests', () => {
 
       // check the main navbar
       expect(doc.querySelector('.navbar-nav>.active').getAttribute('href')).toBe('/manage');
-      expect(doc.querySelector('.navbar-nav>.navbar-text').innerHTML).toContain(
-        'master@uwstout.edu'
-      );
-
 
       // count the rows
       const rows = doc.querySelectorAll('.card-body>table>tbody>tr');

--- a/views/layout/partials/navigation.ejs
+++ b/views/layout/partials/navigation.ejs
@@ -2,9 +2,9 @@
   <div class="container-fluid">
     <div class="navbar-nav">
       <a class="navbar-brand" href="#">Program Course Advisor</a>
-      <a onclick="checkRole('advise')" class="nav-link <%= group === 'advise' ? 'active' : ''%>" href="#">Advise</a>
-      <a onclick="checkRole('manage')" class="nav-link <%= group === 'manage' ? 'active' : ''%>" href="#">Manage</a>
-      <a onclick="checkRole('admin')" class="nav-link <%= group === 'admin' ? 'active' : ''%>" href="#">Admin</a>
+      <a class="nav-link <%= group === 'advise' ? 'active' : ''%>" href="/advise">Advise</a>
+      <a class="nav-link <%= group === 'manage' ? 'active' : ''%>" href="/manage">Manage</a>
+      <a class="nav-link <%= group === 'admin' ? 'active' : ''%>" href="/admin">Admin</a>
     </div>
     <div class="navbar-nav">
       <span class="navbar-text">

--- a/views/layout/partials/scripts.ejs
+++ b/views/layout/partials/scripts.ejs
@@ -30,23 +30,25 @@
 </script>
 
 <script>
-  //Alert user of their role
-  function checkRole(location) {
-    const role = '<%= role %>';
-    if(location === 'admin') {
-      if(role === 'admin') {
-        window.location.href = `/${location}`;
-      } else {
+  //Alert user of their role if it is incorrect
+  function checkRole() {
+    let page = window.location.pathname;
+    console.log(page)
+    const role = '<%=role %>';
+    console.log(role)
+    if (page === '/admin') {
+      console.log('in admin check')
+      if(role !== 'admin') {
         alert('You can\'t access this page because your role does not allow it. Please contact your admin with any questions on your permissions.');
+        window.location.href = '/advise';
       }
-    } else if(location === 'manage') {
-      if(role === 'admin' || role === 'director') {
-        window.location.href = `/${location}`;
-      } else {
+    } else if (page === '/manage') {
+      console.log('in manage check')
+      if(role === 'user') {
         alert('You can\'t access this page because your role does not allow it. Please contact your admin with any questions on your permissions.');
+        window.location.href = '/advise';
       }
-    } else { 
-      window.location.href = `/${location}`;
-    }
+    } 
   }
+  checkRole()
 </script>


### PR DESCRIPTION
Before pages were validated as the user clicked to change between pages. This still allowed the user to enter the / in the URL and still reach the page regardless of role. It now vaildates before the page fully loads to stop that.

For this the admin can reach all pages, directors can reach the advise and manage pages, and the user can only reach the adivise page.